### PR TITLE
Manual auth

### DIFF
--- a/backend/database/util.py
+++ b/backend/database/util.py
@@ -42,7 +42,7 @@ def update_user(steam_id, new_fields):
       
 def find_user_by_email(email):
     user = User.query.filter_by(email=email).first()
-    return bool(user)
+    return user.to_dict() if user else None
 
 def verify_password(email, password):
     user = User.query.filter_by(email=email).first()

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,50 +1,61 @@
-from flask import Blueprint, json, Response, request
-from steam.api import get_steam_id, get_player_summary
-import bcrypt
-auth_blueprint = Blueprint('auth', __name__)
 from database.util import *
+from flask import Blueprint, json, Response, request
+from steam.api import *
+import bcrypt
+import jwt
+auth_blueprint = Blueprint('auth', __name__)
+
 
 @auth_blueprint.route("/register", methods=['POST'])
 def manual_register():
     try:
-        email = request.form['email']
-        password = request.form['password']
-        api_key = request.form['apiKey']
-        steam_url = request.form['steamURL']
-
+        request_data = request.json
+        email = request_data.get('email')
+        password = request_data.get('password')
+        api_key = request_data.get('apiKey')
+        steam_url = request_data.get('steamURL')
         if not email or not password or not api_key or not steam_url:
             return Response(status=400, response=json.dumps({'error': 'Missing required fields'}))
+
+        steam_id = get_steam_id(steam_url, api_key)
 
         hashed_api_key = bcrypt.hashpw(
             api_key.encode('utf-8'), bcrypt.gensalt()).decode()
         hashed_password = bcrypt.hashpw(
             password.encode('utf-8'), bcrypt.gensalt()).decode()
 
-        steam_id = get_steam_id(steam_url)
-        player_summary = get_player_summary(steam_id)["response"]["players"][0]
-        
-        if not id or not player_summary:
+        response = get_player_summary(steam_id, api_key)[
+            "response"]["players"][0]
+
+        if not steam_id or not response:
             return Response(status=400, response=json.dumps({"error": "Steam API failed!"}), content_type='application/json')
-        
+
         user = {
             "steam_id": steam_id,
             "email": email,
-            "username": player_summary["personaname"],
+            "username": response["personaname"],
             "password": hashed_password,
             "login": "manual",
             "api_key": hashed_api_key,
             "steam_url": steam_url,
-            "full_avatar_url": player_summary["avatarfull"]
+            "full_avatar_url": response["avatarfull"]
         }
         if create_user(user):
-            return Response(status=200, response=json.dumps({"message": "User created successfully"}), content_type='application/json')
+            payload = {'user_id': user['steam_id']}
+            token = jwt.encode(payload, os.getenv('JWT_KEY'), algorithm='HS256').decode('utf-8')
+            return Response(status=200, response=json.dumps({
+                                                            "message": "User created successfully",
+                                                            "user": user,
+                                                            "token": token
+                                                            }), content_type='application/json')
         else:
             return Response(status=409, response=json.dumps({"error": "User already exists"}), content_type='application/json')
 
     except Exception as e:
         return Response(status=500, response=json.dumps({"error": "Internal server error", "details": str(e)}))
 
-    
+
+
 @auth_blueprint.route("/login", methods=["POST"])
 def manual_login():
     try:
@@ -57,5 +68,3 @@ def manual_login():
 
     except Exception as e:
         return Response(status=500, response=json.dumps({"error": "Internal server error", "details": str(e)}))
-    
-

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -19,16 +19,14 @@ def manual_register():
             return Response(status=400, response=json.dumps({'error': 'Missing required fields'}))
 
         if find_user_by_email(email):
-            return Response(status=403, response=json.dumps({'error': 'User exists!'}))
+            return Response(status=403, response=json.dumps({'error': 'User already exists!'}))
 
         steam_id = get_steam_id(steam_url, api_key)
-        response = get_player_summary(steam_id, api_key)[
-            "response"]["players"][0]
-
-        if not steam_id:
-            return Response(status=404, response=json.dumps({"error": "API KEY is invalid!"}), content_type='application/json')
-        if not response:
-            return Response(status=404, response=json.dumps({"error": "API key is invalid@ "}), content_type='application/json')
+        if "error" in steam_id:
+            print(steam_id)
+            return Response(status=404, response=json.dumps({"error": steam_id["error"]}), content_type='application/json')
+        
+        response = get_player_summary(steam_id, api_key)["response"]["players"][0]
         hashed_api_key = bcrypt.hashpw(
             api_key.encode('utf-8'), bcrypt.gensalt()).decode()
         hashed_password = bcrypt.hashpw(

--- a/backend/steam/api.py
+++ b/backend/steam/api.py
@@ -17,23 +17,28 @@ def get_player_summary(steam_id, api_key):
         return None
 
 
-def get_steam_id(url):
+def get_steam_id(url, api_key):
     if "/id/" in url:
         parts = url.split("/id/")
         if len(parts) >= 2:
-            steamid_response = get_steam_id_api(parts[1][:-1])["response"]
-            if steamid_response["success"] == 1:
+            vanity_url = parts[1][:-1]
+            steamid_response = get_steam_id_api(
+                vanity_url, api_key)["response"]
+            if steamid_response["success"]:
                 return steamid_response["steamid"]
             else:
                 return parts[1][:-1]
+    elif "/profiles/":
+        parts = url.split("/profiles/")
+        return parts[1]
     else:
         return None
 
 
-def get_steam_id_api(url):
+def get_steam_id_api(url, api_key):
     steam_api_url = "http://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/"
     params = {
-        "key": os.getenv('API_KEY'),
+        "key": api_key,
         "vanityurl": url
     }
     response = requests.get(url=steam_api_url, params=params)

--- a/backend/steam/api.py
+++ b/backend/steam/api.py
@@ -23,11 +23,11 @@ def get_steam_id(url, api_key):
         if len(parts) >= 2:
             vanity_url = parts[1][:-1]
             steamid_response = get_steam_id_api(
-                vanity_url, api_key)["response"]
-            if steamid_response["success"]:
+                vanity_url, api_key)['response']
+            if "success" in steamid_response:
                 return steamid_response["steamid"]
             else:
-                return parts[1][:-1]
+                return steamid_response
     elif "/profiles/":
         parts = url.split("/profiles/")
         return parts[1]
@@ -43,9 +43,13 @@ def get_steam_id_api(url, api_key):
     }
     response = requests.get(url=steam_api_url, params=params)
     if response.status_code == 200:
-        return response.json()
+        json_response = response.json()
+        if json_response.get("response", {}).get("message") != "No match":
+            return json_response
+        else:
+            return {'response': {'error': 'Incorrect Steam URL.'}}
     else:
-        return 'Failure to get steam id. Error: HTTP {}, {}'.format(response.status_code)
+        return {'response': {'error': 'Incorrect API KEY.'}}
 
 
 def get_owned_games():

--- a/client/src/components/PageFormatter.jsx
+++ b/client/src/components/PageFormatter.jsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 import { useAppSelector } from '../redux/store';
 const PageFormatter = () => {
   const { user } = useAppSelector((state) => state.auth);
-  if (user == null) {
+  if (user == null || JSON.stringify(user) === '{}') {
     return (
       <div>
         <h1>Unauthorized</h1>

--- a/client/src/components/SignIn/SignInForm.jsx
+++ b/client/src/components/SignIn/SignInForm.jsx
@@ -1,19 +1,40 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import SignInModal from './SignInModal';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import SteamLogin from './SteamLogin';
+import { useAppDispatch } from '../../redux/store';
+import { loginUser } from '../../redux/feats/auth/authActions';
 function SignInForm() {
   const [email, setEmail] = useState();
   const [password, setPassword] = useState();
 
-  const emailHandler = (event) => {
-    setEmail(event.target.value);
-    console.log(email);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const [emailError, setEmailError] = useState(false);
+  const [passwordError, setPasswordError] = useState(false);
+  const [isMissing, setIsMissing] = useState(false);
+
+  const loginHandler = async () => {
+    try {
+      await dispatch(loginUser({ email: email, password: password })).unwrap();
+      navigate('/auth/main');
+    } catch (error) {
+      let errorMessage = error.response.data.error;
+      setErrorMessage(errorMessage);
+      if (errorMessage.includes('User')) {
+        console.log('for email');
+        setEmailError(true);
+      } else if (errorMessage.includes('Password')) {
+        setPasswordError(true);
+      } else {
+        setIsMissing(true);
+      }
+    }
   };
-  const passwordHandler = (event) => {
-    setPassword(event.target.value);
-    console.log(password);
-  };
+
   return (
     <div className="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
       <div className="card-body">
@@ -22,22 +43,38 @@ function SignInForm() {
             <span className="label-text">Email</span>
           </label>
           <input
-            onChange={emailHandler}
+            onChange={(event) => setEmail(event.target.value)}
             type="text"
             placeholder="email"
-            className="input input-bordered"
+            className={`input input-bordered border ${
+              emailError || isMissing ? 'border-rose-500' : ''
+            }`}
           />
+          {emailError && (
+            <span className="text-xs text-red-500">{errorMessage}</span>
+          )}
+          {isMissing && (
+            <span className="text-xs text-red-500">{errorMessage}</span>
+          )}
         </div>
         <div className="form-control">
           <label className="label">
             <span className="label-text">Password</span>
           </label>
           <input
-            onChange={passwordHandler}
-            type="text"
+            onChange={(event) => setPassword(event.target.value)}
+            type="password"
             placeholder="password"
-            className="input input-bordered"
+            className={`input input-bordered border ${
+              passwordError || isMissing ? 'border-rose-500' : ''
+            }`}
           />
+          {passwordError && (
+            <span className="text-xs text-red-500">{errorMessage}</span>
+          )}
+          {isMissing && (
+            <span className="text-xs text-red-500">{errorMessage}</span>
+          )}
           <div className="flex">
             <label className="label">
               <SignInModal />
@@ -50,7 +87,9 @@ function SignInForm() {
           </div>
         </div>
         <div className="form-control mt-2">
-          <button className="btn btn-primary">Login</button>
+          <button className="btn btn-primary" onClick={loginHandler}>
+            Login
+          </button>
         </div>
         <div className="form-control">
           <SteamLogin />

--- a/client/src/components/Signup/SignUpForm.jsx
+++ b/client/src/components/Signup/SignUpForm.jsx
@@ -1,6 +1,9 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import SteamLogin from '../SignIn/SteamLogin';
+import { useAppDispatch } from '../../redux/store';
+import { useNavigate } from 'react-router-dom';
+import { registerUser } from '../../redux/feats/auth/authActions';
 const SignUpForm = () => {
   const emailRef = useRef(null);
   const passwordRef = useRef(null);
@@ -8,14 +11,24 @@ const SignUpForm = () => {
   const steamURLRef = useRef(null);
   const apiKeyRef = useRef(null);
 
-  const registerAccount = () => {
-    console.log(
-      emailRef.current.value,
-      passwordRef.current.value,
-      confirmPasswordRef.current.value,
-      steamURLRef.current.value,
-      apiKeyRef.current.value
-    );
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState(false);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const registerAccount = async () => {
+    try {
+      await dispatch(
+        registerUser({
+          email: emailRef.current.value,
+          password: passwordRef.current.value,
+          steamURL: steamURLRef.current.value,
+          apiKey: apiKeyRef.current.value,
+        })).unwrap();
+        navigate('auth/main');
+    } catch (error) {
+      console.log(error);
+    }
   };
   return (
     <div className="space-y-4 md:space-y-6 p-4">

--- a/client/src/components/Signup/SignUpForm.jsx
+++ b/client/src/components/Signup/SignUpForm.jsx
@@ -11,12 +11,27 @@ const SignUpForm = () => {
   const steamURLRef = useRef(null);
   const apiKeyRef = useRef(null);
 
-  const [emailError, setEmailError] = useState('');
+  const [isMissing, setIsMissing] = useState(false);
+  const [missingMessage, setMissingMessage] = useState('');
+
+  const [invalidCred, setInvalidCred] = useState(false);
+  const [credMessage, setCredMessage] = useState('');
+
+  const [isFound, setIsFound] = useState(false);
+  const [foundMessage, setFoundMessage] = useState('');
+
   const [passwordError, setPasswordError] = useState(false);
+  const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
+
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const registerAccount = async () => {
+    if (passwordRef.current.value !== confirmPasswordRef.current.value) {
+      setPasswordError(true);
+      setPasswordErrorMessage('Password do not match');
+      return;
+    }
     try {
       await dispatch(
         registerUser({
@@ -24,10 +39,24 @@ const SignUpForm = () => {
           password: passwordRef.current.value,
           steamURL: steamURLRef.current.value,
           apiKey: apiKeyRef.current.value,
-        })).unwrap();
-        navigate('auth/main');
+        })
+      ).unwrap();
+      navigate('/auth/main');
     } catch (error) {
-      console.log(error);
+      const res = error.response;
+      const errorMessage = res.data.error;
+      if (res.status === 400) {
+        setIsMissing(true);
+        setMissingMessage(errorMessage);
+      } else if (res.status === 403) {
+        setIsFound(true);
+        setFoundMessage(errorMessage);
+      } else if (res.status === 404) {
+        setInvalidCred(true);
+        setCredMessage(errorMessage);
+      } else {
+        console.log(error);
+      }
     }
   };
   return (
@@ -45,9 +74,20 @@ const SignUpForm = () => {
           name="email"
           id="email"
           required=""
-          className="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
           placeholder="name@company.com"
+          className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+          ${
+            isFound || isMissing
+              ? 'border-red-500 dark:border-red-700'
+              : 'border-gray-300 dark:border-gray-600'
+          }`}
         />
+        {isMissing && (
+          <span className="text-xs text-red-500">{missingMessage}</span>
+        )}
+        {isFound && (
+          <span className="text-xs text-red-500">{foundMessage}</span>
+        )}
       </div>
       <div>
         <label
@@ -63,8 +103,19 @@ const SignUpForm = () => {
           id="password"
           placeholder="••••••••"
           required=""
-          className="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+          ${
+            passwordError || isMissing
+              ? 'border-red-500 dark:border-red-700'
+              : 'border-gray-300 dark:border-gray-600'
+          }`}
         />
+        {isMissing && (
+          <span className="text-xs text-red-500">{missingMessage}</span>
+        )}
+        {passwordError && (
+          <span className="text-xs text-red-500">{passwordErrorMessage}</span>
+        )}
       </div>
       <div>
         <label
@@ -80,8 +131,19 @@ const SignUpForm = () => {
           id="confirm-password"
           placeholder="••••••••"
           required=""
-          className="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+          ${
+            passwordError || isMissing
+              ? 'border-red-500 dark:border-red-700'
+              : 'border-gray-300 dark:border-gray-600'
+          }`}
         />
+        {isMissing && (
+          <span className="text-xs text-red-500">{missingMessage}</span>
+        )}
+        {passwordError && (
+          <span className="text-xs text-red-500">{passwordErrorMessage}</span>
+        )}
       </div>
       <div>
         <label
@@ -97,8 +159,19 @@ const SignUpForm = () => {
           id="steamURL"
           placeholder="https://steamcommunity.com/id/PlentyJapan"
           required=""
-          className="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+          ${
+            invalidCred || isMissing
+              ? 'border-red-500 dark:border-red-700'
+              : 'border-gray-300 dark:border-gray-600'
+          }`}
         />
+        {isMissing && (
+          <span className="text-xs text-red-500">{missingMessage}</span>
+        )}
+        {invalidCred && (
+          <span className="text-xs text-red-500">{credMessage}</span>
+        )}
       </div>
       <div>
         <label
@@ -114,8 +187,19 @@ const SignUpForm = () => {
           id="apiKEY"
           placeholder="••••••••••••••"
           required=""
-          className="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+          ${
+            invalidCred || isMissing
+              ? 'border-red-500 dark:border-red-700'
+              : 'border-gray-300 dark:border-gray-600'
+          }`}
         />
+        {isMissing && (
+          <span className="text-xs text-red-500">{missingMessage}</span>
+        )}
+        {invalidCred && (
+          <span className="text-xs text-red-500">{credMessage}</span>
+        )}
       </div>
       <button
         type="submit"

--- a/client/src/components/Signup/SignUpForm.jsx
+++ b/client/src/components/Signup/SignUpForm.jsx
@@ -14,8 +14,11 @@ const SignUpForm = () => {
   const [isMissing, setIsMissing] = useState(false);
   const [missingMessage, setMissingMessage] = useState('');
 
-  const [invalidCred, setInvalidCred] = useState(false);
-  const [credMessage, setCredMessage] = useState('');
+  const [invalidAPIKey, setInvalidAPIKey] = useState(false);
+  const [keyMessage, setKeyMessage] = useState('');
+
+  const [invalidURL, setInvalidURL] = useState(false);
+  const [urlMessage, setUrlMessage] = useState('');
 
   const [isFound, setIsFound] = useState(false);
   const [foundMessage, setFoundMessage] = useState('');
@@ -52,8 +55,14 @@ const SignUpForm = () => {
         setIsFound(true);
         setFoundMessage(errorMessage);
       } else if (res.status === 404) {
-        setInvalidCred(true);
-        setCredMessage(errorMessage);
+        let error = res.data.error;
+        if (error.includes('API KEY')) {
+          setInvalidAPIKey(true);
+          setKeyMessage(error);
+        } else {
+          setInvalidURL(true);
+          setUrlMessage(error);
+        }
       } else {
         console.log(error);
       }
@@ -161,7 +170,7 @@ const SignUpForm = () => {
           required=""
           className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
           ${
-            invalidCred || isMissing
+            invalidURL || isMissing
               ? 'border-red-500 dark:border-red-700'
               : 'border-gray-300 dark:border-gray-600'
           }`}
@@ -169,8 +178,8 @@ const SignUpForm = () => {
         {isMissing && (
           <span className="text-xs text-red-500">{missingMessage}</span>
         )}
-        {invalidCred && (
-          <span className="text-xs text-red-500">{credMessage}</span>
+        {invalidURL && (
+          <span className="text-xs text-red-500">{urlMessage}</span>
         )}
       </div>
       <div>
@@ -187,9 +196,9 @@ const SignUpForm = () => {
           id="apiKEY"
           placeholder="••••••••••••••"
           required=""
-          className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+          className={`bg-gray-50 border text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700  dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
           ${
-            invalidCred || isMissing
+            invalidAPIKey || isMissing
               ? 'border-red-500 dark:border-red-700'
               : 'border-gray-300 dark:border-gray-600'
           }`}
@@ -197,8 +206,8 @@ const SignUpForm = () => {
         {isMissing && (
           <span className="text-xs text-red-500">{missingMessage}</span>
         )}
-        {invalidCred && (
-          <span className="text-xs text-red-500">{credMessage}</span>
+        {invalidAPIKey && (
+          <span className="text-xs text-red-500">{keyMessage}</span>
         )}
       </div>
       <button

--- a/client/src/components/Signup/SignUpForm.jsx
+++ b/client/src/components/Signup/SignUpForm.jsx
@@ -5,12 +5,14 @@ import { useAppDispatch } from '../../redux/store';
 import { useNavigate } from 'react-router-dom';
 import { registerUser } from '../../redux/feats/auth/authActions';
 const SignUpForm = () => {
+  // Input states
   const emailRef = useRef(null);
   const passwordRef = useRef(null);
   const confirmPasswordRef = useRef(null);
   const steamURLRef = useRef(null);
   const apiKeyRef = useRef(null);
 
+  // Error states
   const [isMissing, setIsMissing] = useState(false);
   const [missingMessage, setMissingMessage] = useState('');
 

--- a/client/src/redux/feats/auth/authActions.js
+++ b/client/src/redux/feats/auth/authActions.js
@@ -1,10 +1,10 @@
 import Axios from 'axios';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
-let BASE_URL = 'http://localhost:3001/api/auth';
+let BASE_URL = 'http://localhost:8000/api/auth';
 
 export const loginUser = createAsyncThunk(
-  'api/auth/login',
+  '/login',
   async (user, { rejectWithValue }) => {
     try {
       const data = await Axios.post(`${BASE_URL}/login`, user);
@@ -16,33 +16,11 @@ export const loginUser = createAsyncThunk(
 );
 
 export const registerUser = createAsyncThunk(
-  '/api/auth/register',
+  '/register',
   async (user, { rejectWithValue }) => {
     try {
       const result = await Axios.post(`${BASE_URL}/register`, user);
       return result;
-    } catch (error) {
-      return rejectWithValue(error);
-    }
-  }
-);
-
-export const steamLogin = createAsyncThunk(
-  'api/auth/steamLogin',
-  async ({ rejectWithValue }) => {
-    try {
-      const response = await fetch(
-        `http://localhost:8000/api/steam_auth/steam-login`
-      );
-      const data = await response.json();
-
-      // Handle error response from server
-      if (!response.ok) {
-        throw new Error(data.message || 'Failed to log in with Steam');
-      }
-
-      // Return data which includes user and token
-      return data;
     } catch (error) {
       return rejectWithValue(error);
     }

--- a/client/src/redux/feats/auth/authSlice.js
+++ b/client/src/redux/feats/auth/authSlice.js
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { loginUser, registerUser, steamLogin } from './authActions';
+import { loginUser, registerUser } from './authActions';
 
-const userFromStorage = localStorage.getItem('steam');
-const tokenFromStorage = localStorage.getItem('token');
+const userFromStorage = localStorage.getItem('steam_user');
+const tokenFromStorage = localStorage.getItem('steam_token');
 
 const initialState = {
   user: userFromStorage ? JSON.parse(userFromStorage) : {},
@@ -20,8 +20,8 @@ const authSlice = createSlice({
       state.token = '';
       state.loading = false;
       state.error = null;
-      localStorage.removeItem('token');
-      localStorage.removeItem('user');
+      localStorage.removeItem('steam_token');
+      localStorage.removeItem('steam_user');
     },
     updateUserDetails: (state, action) => {
       state.user = action.payload;
@@ -37,8 +37,8 @@ const authSlice = createSlice({
         state.loading = false;
         state.user = payload.data.user;
         state.token = payload.data.token;
-        localStorage.setItem('user', JSON.stringify(payload.data.user));
-        localStorage.setItem('token', payload.data.token);
+        localStorage.setItem('steam_user', JSON.stringify(payload.data.user));
+        localStorage.setItem('steam_token', payload.data.token);
       })
       .addCase(loginUser.rejected, (state, { payload }) => {
         state.loading = false;
@@ -51,8 +51,8 @@ const authSlice = createSlice({
       .addCase(registerUser.fulfilled, (state, { payload }) => {
         state.loading = false;
         state.user = payload.data.user;
-        localStorage.setItem('user', JSON.stringify(payload.data.user));
-        localStorage.setItem('token', payload.data.token);
+        localStorage.setItem('steam_user', JSON.stringify(payload.data.user));
+        localStorage.setItem('steam_token', payload.data.token);
       })
       .addCase(registerUser.rejected, (state, { payload }) => {
         state.loading = false;


### PR DESCRIPTION
# Manual Auth
- Handled each error case, on both frontend and backend
- Sends a JWT on both endpoints
<img width="790" alt="Screenshot 2024-03-25 at 6 51 15 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/3823ae2e-9cfb-4231-9a9f-37246e5ea2db">

## Manual Register 
- Users can now register manually on the frontend 
- Validates API keys and steam URL, for steam metadata.
### Missing Fields
<img width="1112" alt="Screenshot 2024-03-25 at 6 23 56 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/bf6cc74e-4722-443b-9f9d-f66c6a1949a4">

### Missing User
<img width="458" alt="Screenshot 2024-03-25 at 6 25 20 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/41771f09-be00-4bde-b9c0-eaf7e3a5e41d">

### Invalid Password
<img width="483" alt="Screenshot 2024-03-25 at 6 25 50 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/b8904fcd-99d6-4827-95bc-7d8950aeead8">

### Invalid URL
<img width="443" alt="Screenshot 2024-03-25 at 6 26 37 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/5d6fbe54-bd27-4a87-b26b-b9d58eedf477">

### Invalid API KEY
<img width="448" alt="Screenshot 2024-03-25 at 6 27 09 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/33d5d517-c862-44bc-9e74-ee811c91c08a">

# Manual Login
- User can now login manually on the frontend. 
- Saves on local storage.
## Screenshots
### Missing Fields
<img width="668" alt="Screenshot 2024-03-25 at 6 49 35 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/fd555106-cfc4-4563-8042-447361d9a660">

### Wrong Email
<img width="635" alt="Screenshot 2024-03-25 at 6 50 28 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/57baeaec-d31f-41ae-a63b-7edabd5f944e">

### Wrong Password

<img width="686" alt="Screenshot 2024-03-25 at 6 50 40 PM" src="https://github.com/KyoshiNoda/Steam-Time/assets/62672803/58f7b136-ddec-4b37-a58d-2ef0f4f9e272">